### PR TITLE
Allow Sidekiq::Web to use Redis namespace if configured

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,5 @@
 source "https://rubygems.org"
 
 gem "sidekiq"
+gem "redis-namespace"
 gem 'sinatra', "~> 1.4"

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source "https://rubygems.org"
 
 gem "sidekiq"
 gem "redis-namespace"
-gem 'sinatra', "~> 1.4"
+gem 'sinatra', "~> 2.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,16 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    concurrent-ruby (1.0.5)
-    connection_pool (2.2.2)
-    rack (1.6.10)
+    connection_pool (2.2.5)
+    rack (1.6.13)
     rack-protection (1.5.5)
       rack
-    redis (4.0.1)
+    redis (4.5.1)
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
-    sidekiq (5.1.3)
-      concurrent-ruby (~> 1.0)
-      connection_pool (~> 2.2, >= 2.2.0)
+    sidekiq (5.2.8)
+      connection_pool (~> 2.2, >= 2.2.2)
+      rack (< 2.1.0)
       rack-protection (>= 1.5.0)
       redis (>= 3.3.5, < 5)
     sinatra (1.4.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,8 @@ GEM
     rack-protection (1.5.5)
       rack
     redis (4.0.1)
+    redis-namespace (1.6.0)
+      redis (>= 3.0.4)
     sidekiq (5.1.3)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
@@ -22,6 +24,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  redis-namespace
   sidekiq
   sinatra (~> 1.4)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,22 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    concurrent-ruby (1.0.2)
-    connection_pool (2.2.0)
-    rack (1.6.4)
-    rack-protection (1.5.3)
+    concurrent-ruby (1.0.5)
+    connection_pool (2.2.2)
+    rack (1.6.10)
+    rack-protection (1.5.5)
       rack
-    redis (3.3.0)
-    sidekiq (4.1.1)
+    redis (4.0.1)
+    sidekiq (5.1.3)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
-      redis (~> 3.2, >= 3.2.1)
-    sinatra (1.4.7)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.5, < 5)
+    sinatra (1.4.8)
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
-    tilt (2.0.2)
+    tilt (2.0.8)
 
 PLATFORMS
   ruby
@@ -25,4 +26,4 @@ DEPENDENCIES
   sinatra (~> 1.4)
 
 BUNDLED WITH
-   1.10.6
+   1.16.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,21 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    connection_pool (2.2.5)
+    connection_pool (2.3.0)
     rack (1.6.13)
     rack-protection (1.5.5)
       rack
-    redis (4.5.1)
+    redis (5.0.5)
+      redis-client (>= 0.9.0)
+    redis-client (0.10.0)
+      connection_pool
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
-    sidekiq (5.2.8)
-      connection_pool (~> 2.2, >= 2.2.2)
-      rack (< 2.1.0)
+    sidekiq (6.0.0.pre1)
+      connection_pool (>= 2.2.2)
+      rack (>= 1.5.0)
       rack-protection (>= 1.5.0)
-      redis (>= 3.3.5, < 5)
+      redis (>= 4.0.2)
     sinatra (1.4.8)
       rack (~> 1.5)
       rack-protection (~> 1.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,10 @@ GEM
   remote: https://rubygems.org/
   specs:
     connection_pool (2.3.0)
-    rack (1.6.13)
-    rack-protection (1.5.5)
+    mustermann (1.1.2)
+      ruby2_keywords (~> 0.0.1)
+    rack (2.2.4)
+    rack-protection (2.2.0)
       rack
     redis (5.0.5)
       redis-client (>= 0.9.0)
@@ -11,16 +13,18 @@ GEM
       connection_pool
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
+    ruby2_keywords (0.0.5)
     sidekiq (6.0.0.pre1)
       connection_pool (>= 2.2.2)
       rack (>= 1.5.0)
       rack-protection (>= 1.5.0)
       redis (>= 4.0.2)
-    sinatra (1.4.8)
-      rack (~> 1.5)
-      rack-protection (~> 1.4)
-      tilt (>= 1.3, < 3)
-    tilt (2.0.8)
+    sinatra (2.2.0)
+      mustermann (~> 1.0)
+      rack (~> 2.2)
+      rack-protection (= 2.2.0)
+      tilt (~> 2.0)
+    tilt (2.0.11)
 
 PLATFORMS
   ruby
@@ -28,7 +32,7 @@ PLATFORMS
 DEPENDENCIES
   redis-namespace
   sidekiq
-  sinatra (~> 1.4)
+  sinatra (~> 2.2)
 
 BUNDLED WITH
    1.16.2

--- a/config.ru
+++ b/config.ru
@@ -1,7 +1,9 @@
 require 'sidekiq'
 
 Sidekiq.configure_client do |config|
-  config.redis = { url: ENV.fetch("REDIS_URL") }
+  redis_config = { url: ENV.fetch("REDIS_URL") }
+  redis_config.merge!(namespace: ENV["REDIS_NAMESPACE"]) if ENV["REDIS_NAMESPACE"]
+  config.redis = redis_config
 end
 
 require 'sidekiq/web'


### PR DESCRIPTION
If the environment variable `REDIS_NAMESPACE` has a value then we configure Sidekiq's Redis connection to use it.

This means including the `redis-namespace` gem. Sidekiq::Web is already aware of namespaces.